### PR TITLE
Fixing security risk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2023.5.7
 charset-normalizer==3.1.0
 dill==0.3.6
 google-api-python-client==1.7.2
-google-auth==1.8.0
+google-auth==1.23.0
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.1
 httplib2==0.22.0


### PR DESCRIPTION
Unblocking rsa upgrade by upgrading google-auth from 1.8.0 to 1.23.0

Referenece: https://github.com/prosolis/music/pull/27