### PR TITLE
Create mpd_bot docker image

### DIFF
--- a/.github/workflows/docker-image-mpd.yml
+++ b/.github/workflows/docker-image-mpd.yml
@@ -1,0 +1,34 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: prosolismusicradio/mpd_bot   
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./docker/mpd/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/bots/helpers/postgres/postgresproxy.py
+++ b/bots/helpers/postgres/postgresproxy.py
@@ -41,6 +41,7 @@ class PostgresProxy:
             return None
 
         logger.info("Connection to Postgres SQL Database established")
+
         return conn
 
     async def postgres_connection_close(self):
@@ -145,6 +146,8 @@ class PostgresProxy:
             logger.error("Was unable to finish, issue with artist_exists: %s", error)
             self.print_psycopg2_exception(error)
 
+        cursor.close()
+
     async def song_exists(self, title, artist, fingerprint):
         """Does the given song already exist inside the DB if not insert the song"""
         logger = logging.getLogger('PostgresProxy')
@@ -178,6 +181,8 @@ class PostgresProxy:
             logger.error("Was unable to finsih, issue with song_exists: %s", error)
             self.print_psycopg2_exception(error)
 
+        cursor.close()
+
     async def insert_play_history(self, title, artist, fingerprint):
         """insert the song into play history"""
         logger = logging.getLogger('PostgresProxy')
@@ -199,6 +204,8 @@ class PostgresProxy:
         except Exception as error:
             logger.error("Was unable to finsih, issue with insert_play_history: %s", error)
             self.print_psycopg2_exception(error)
+
+        cursor.close()
 
     def print_psycopg2_exception(self, error):
         """Define a function that handles and parses psycopg2 exceptions"""

--- a/bots/mpd_bot.py
+++ b/bots/mpd_bot.py
@@ -11,10 +11,9 @@ from helpers.postgres import postgresproxy
 async def main():
     """Initializes Prosolis Radio Bot for MPD."""
     log_format = '%(asctime)s %(message)s'
-    log_level = 30
+    log_level = 10
 
-    logging.basicConfig(filename='mpd_bot.log', filemode='a',
-                        level=log_level, format=log_format, encoding="UTF-8")
+    logging.basicConfig(level=log_level, format=log_format, encoding="UTF-8")
     logger = logging.getLogger('MPDBot')
     logger.info("MPD Bot has started")
 

--- a/bots/mpd_bot.py
+++ b/bots/mpd_bot.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 import os
+import gc
 from dotenv import load_dotenv
 
 from helpers.musicplayer import mpdproxy
@@ -13,9 +14,12 @@ async def main():
     log_format = '%(asctime)s %(message)s'
     log_level = 10
 
-    logging.basicConfig(level=log_level, format=log_format, encoding="UTF-8")
+    logging.basicConfig(filename='/app/logs/mpd_bot.log', filemode='a',
+                        level=log_level, format=log_format, encoding="UTF-8")
     logger = logging.getLogger('MPDBot')
     logger.info("MPD Bot has started")
+
+    gc.enable()
 
     load_dotenv()
     metadata_folderpath = os.getenv("METADATA_PATH")
@@ -82,6 +86,8 @@ async def check_song_exists(fingerprint, title, artist):
     logger.info("%s by %s exists inside DB", title, artist)
     logger.info("Finished check_song_exists")
 
+    del postgres
+
 async def update_play_history(fingerprint, title, artist):
     """Update play_history table with current song"""
     logger = logging.getLogger('MPDBot')
@@ -94,6 +100,8 @@ async def update_play_history(fingerprint, title, artist):
 
     logger.info("Finished update_play_history")
 
+    del postgres
+
 async def check_metadata_folder(metadata_folderpath):
     """Check if metadata is found and if not create it"""
     logger = logging.getLogger('MPDBot')
@@ -103,6 +111,8 @@ async def check_metadata_folder(metadata_folderpath):
     if not folder_exist:
         os.makedirs(metadata_folderpath)
         logger.info("Metadata file created at %s", metadata_folderpath)
+
+    del folder_exist
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,8 @@ services:
       METADATA_PATH: ./metadata
       POSTGRES_USER: <postgres_user>
       POSTGRES_PASSWORD: <postgres_password>
+    deploy:
+      resources:
+        limits:
+          cpus: '0.01'
+          memory: 50M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,15 @@
-version: '3'
+version: '3.9'
 services:
-  mpd:
+  mpd_bot:
     # will build ./docker/mpd/Dockerfile
     build:
       context: .
       dockerfile: ./docker/mpd/Dockerfile
+    container_name: mpd_bot
+    network_mode: "host"
+    volumes: 
+      - <host_metadata_path>:/metadata
+    environment:
+      METADATA_PATH: ./metadata
+      POSTGRES_USER: <postgres_user>
+      POSTGRES_PASSWORD: <postgres_password>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  mpd:
+    # will build ./docker/mpd/Dockerfile
+    build:
+      context: .
+      dockerfile: ./docker/mpd/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,22 @@
 version: '3.9'
 services:
   mpd_bot:
-    # will build ./docker/mpd/Dockerfile
-    build:
-      context: .
-      dockerfile: ./docker/mpd/Dockerfile
     container_name: mpd_bot
     network_mode: "host"
     volumes: 
       - <host_metadata_path>:/metadata
+      - <host_logs_path>:/app/logs
     environment:
       METADATA_PATH: ./metadata
       POSTGRES_USER: <postgres_user>
       POSTGRES_PASSWORD: <postgres_password>
+      PUID: <user_puid>
+      PGID: <group_pgid>
     deploy:
       resources:
         limits:
           cpus: '0.01'
           memory: 50M
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true

--- a/docker/mpd/Dockerfile
+++ b/docker/mpd/Dockerfile
@@ -1,12 +1,16 @@
 FROM python:3.11.4
 
-COPY ./bots/mpd_bot.py /src/mpd_bot.py
+RUN mkdir ./metadata
 
-COPY ./bots/helpers/musicplayer/* /src/helpers/musicplayer/
+WORKDIR /app
 
-COPY ./bots/helpers/postgres/* /src/helpers/postgres/
+COPY ./bots/mpd_bot.py ./mpd_bot.py
 
-RUN chmod +x /src
+COPY ./bots/helpers/musicplayer/* ./helpers/musicplayer/
+
+COPY ./bots/helpers/postgres/* ./helpers/postgres/
+
+RUN chmod +x .
 
 RUN apt update & apt upgrade
 
@@ -15,10 +19,10 @@ RUN pip install -U \
     setuptools \
     wheel
 
-COPY requirements.txt /src/requirements.txt
+COPY requirements.txt ./requirements.txt
 
-RUN pip install -r /src/requirements.txt
+RUN pip install -r ./requirements.txt
 
-WORKDIR /src
+ENV METADATA_PATH="./metadata"
 
-RUN mpd_bot.py
+CMD [ "python","./mpd_bot.py"]

--- a/docker/mpd/Dockerfile
+++ b/docker/mpd/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.11.4
 
 RUN mkdir ./metadata
 
+RUN mkdir ./logs
+
 WORKDIR /app
 
 COPY ./bots/mpd_bot.py ./mpd_bot.py
@@ -22,7 +24,5 @@ RUN pip install -U \
 COPY requirements.txt ./requirements.txt
 
 RUN pip install -r ./requirements.txt
-
-ENV METADATA_PATH="./metadata"
 
 CMD [ "python","./mpd_bot.py"]

--- a/docker/mpd/Dockerfile
+++ b/docker/mpd/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11.4
+
+COPY ./bots/mpd_bot.py /src/mpd_bot.py
+
+COPY ./bots/helpers/musicplayer/* /src/helpers/musicplayer/
+
+COPY ./bots/helpers/postgres/* /src/helpers/postgres/
+
+RUN chmod +x /src
+
+RUN apt update & apt upgrade
+
+RUN pip install -U \
+    pip \
+    setuptools \
+    wheel
+
+COPY requirements.txt /src/requirements.txt
+
+RUN pip install -r /src/requirements.txt
+
+WORKDIR /src
+
+RUN mpd_bot.py

--- a/docker/mpd/Dockerfile
+++ b/docker/mpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.4
+FROM python:3.11.4-slim-bookworm
 
 RUN mkdir ./metadata
 


### PR DESCRIPTION
In the PR we have a new docker image that containerizes the mpd_bot.

The container is configured with the ./docker/mpd/Dockerfile.

The container image is built and published using the docker-image-mpd,yml GitHub Action file.

Once the build is made successfully it will **publicly** be available in Docker Hub: prosolismusicradio/mpd_bot